### PR TITLE
Add missing ssh banners

### DIFF
--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -392,7 +392,7 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.0"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+[-6|squeeze].*)$">
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-6(?:squeeze)?.*)$">
     <description>OpenSSH running on Debian 6.0 (squeeze)</description>
     <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
     <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -313,7 +313,6 @@ fingerprint SSH servers.
     <param pos="0" name="service.vendor" value="OpenBSD"/>
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
-    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.6(?:\.\d)?p1) (Ubuntu-2ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 14.04</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -304,10 +304,11 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn13v11)$">
+  <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn\d+v\d+)$">
     <description>OpenSSH with HPN patches</description>
     <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
     <example service.version="5.8p1" openssh.comment="hpn13v11">OpenSSH_5.8p1-hpn13v11</example>
+    <example service.version="5.8p1" openssh.comment="hpn14v9">OpenSSH_5.8p1-hpn14v9</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -479,9 +479,9 @@ fingerprint SSH servers.
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
     <param pos="0" name="os.vendor" value="HipServ"/>
-    <param pos="0" name="os.device" value="Router"/>
-    <param pos="0" name="os.family" value="RouterOS"/>
-    <param pos="0" name="os.product" value="RouterOS"/>
+    <param pos="0" name="os.device" value="NAS"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="HipServ"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(.*) in DesktopAuthority (?:.*)$">
     <description>DesktopAuthority SSH</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -290,7 +290,7 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_(6\.1p1)_(Debian-4)$">
+  <fingerprint pattern="^OpenSSH_(6\.1p1) (Debian-4)$">
     <description>OpenSSH running on Ubuntu 13.04</description>
     <example>OpenSSH_6.1p1 Debian-4</example>
     <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -381,9 +381,10 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="8.0"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+[-6|squeeze].*)$">
     <description>OpenSSH running on Debian 6.0 (squeeze)</description>
     <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
+    <example service.version="5.5p1" openssh.comment="Debian-6">OpenSSH_5.5p1 Debian-6</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -304,9 +304,10 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_(6\.1)_(hpn13v11)$">
+  <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn13v11)$">
     <description>OpenSSH</description>
     <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
+    <example service.version="5.8p1" openssh.comment="hpn13v11">OpenSSH_5.8p1-hpn13v11</example>
     <param pos="1" name="service.version"/>
     <param pos="2" name="openssh.comment"/>
     <param pos="0" name="service.vendor" value="OpenBSD"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -290,7 +290,7 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="12.10"/>
   </fingerprint>
-  <fingerprint pattern="^OpenSSH_(6\.1p1) (Debian-4)$">
+  <fingerprint pattern="^OpenSSH_(6\.1p1)_(Debian-4)$">
     <description>OpenSSH running on Ubuntu 13.04</description>
     <example>OpenSSH_6.1p1 Debian-4</example>
     <param pos="1" name="service.version"/>
@@ -303,6 +303,16 @@ fingerprint SSH servers.
     <param pos="0" name="os.family" value="Linux"/>
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="13.04"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(6\.1)_(hpn13v11)$">
+    <description>OpenSSH</description>
+    <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.device" value="General"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(6\.6(?:\.\d)?p1) (Ubuntu-2ubuntu\d+(?:\.\d+)?)$">
     <description>OpenSSH running on Ubuntu 14.04</description>
@@ -493,6 +503,17 @@ fingerprint SSH servers.
     <param pos="0" name="os.vendor" value="Microsoft"/>
     <param pos="0" name="os.family" value="Windows"/>
     <param pos="0" name="os.product" value="Windows"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?) ((?:PKIX\s+)?FIPS)$">
+    <description>OpenSSH with a version and FIPS mode enabled</description>
+    <example service.version="5.9" openssh.comment="FIPS">OpenSSH_5.9 FIPS</example>
+    <example service.version="6.2" openssh.comment="PKIX FIPS">OpenSSH_6.2 PKIX FIPS</example>
+    <example service.version="3.8.1p1" openssh.comment="FIPS">OpenSSH_3.8.1p1 FIPS</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)$">
     <description>OpenSSH with just a version, no comment by vendor</description>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -305,7 +305,7 @@ fingerprint SSH servers.
     <param pos="0" name="os.version" value="13.04"/>
   </fingerprint>
   <fingerprint pattern="^OpenSSH_(\d+\.\d+(?:\.\d+)?(?:p\d+)?)[_|-](hpn13v11)$">
-    <description>OpenSSH</description>
+    <description>OpenSSH with HPN patches</description>
     <example service.version="6.1" openssh.comment="hpn13v11">OpenSSH_6.1_hpn13v11</example>
     <example service.version="5.8p1" openssh.comment="hpn13v11">OpenSSH_5.8p1-hpn13v11</example>
     <param pos="1" name="service.version"/>

--- a/xml/ssh_banners.xml
+++ b/xml/ssh_banners.xml
@@ -349,6 +349,38 @@ fingerprint SSH servers.
     <param pos="0" name="os.product" value="Linux"/>
     <param pos="0" name="os.version" value="7.0"/>
   </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian-5(?:\+deb8u\d+)?)$">
+    <description>OpenSSH running on Debian 8.x (jessie)</description>
+    <example service.version="6.7p1" openssh.comment="Debian-5">OpenSSH_6.7p1 Debian-5</example>
+    <example service.version="6.7p1" openssh.comment="Debian-5+deb8u1">OpenSSH_6.7p1 Debian-5+deb8u1</example>
+    <example service.version="6.7p1" openssh.comment="Debian-5+deb8u2">OpenSSH_6.7p1 Debian-5+deb8u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="Debian"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Raspbian-5(?:\+deb8u\d+)?)$">
+    <description>OpenSSH running on Raspbian 8.x (jessie)</description>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5">OpenSSH_6.7p1 Raspbian-5</example>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u1">OpenSSH_6.7p1 Raspbian-5+deb8u1</example>
+    <example service.version="6.7p1" openssh.comment="Raspbian-5+deb8u2">OpenSSH_6.7p1 Raspbian-5+deb8u2</example>
+    <param pos="1" name="service.version"/>
+    <param pos="2" name="openssh.comment"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="Raspbian"/>
+    <param pos="0" name="os.device" value="General"/>
+    <param pos="0" name="os.family" value="Linux"/>
+    <param pos="0" name="os.product" value="Linux"/>
+    <param pos="0" name="os.version" value="8.0"/>
+  </fingerprint>
   <fingerprint pattern="^OpenSSH_([^\s]+)\s+(Debian.+squeeze.*)$">
     <description>OpenSSH running on Debian 6.0 (squeeze)</description>
     <example service.version="5.5p1" openssh.comment="Debian-6+squeeze4">OpenSSH_5.5p1 Debian-6+squeeze4</example>
@@ -435,6 +467,18 @@ fingerprint SSH servers.
     <param pos="0" name="service.family" value="OpenSSH"/>
     <param pos="0" name="service.product" value="OpenSSH"/>
     <param pos="0" name="os.vendor" value="MikroTik"/>
+    <param pos="0" name="os.device" value="Router"/>
+    <param pos="0" name="os.family" value="RouterOS"/>
+    <param pos="0" name="os.product" value="RouterOS"/>
+  </fingerprint>
+  <fingerprint pattern="^OpenSSH_(.*)-HipServ$">
+    <description>OpenSSH on HipServ</description>
+    <example service.version="4.3">OpenSSH_4.3-HipServ</example>
+    <param pos="1" name="service.version"/>
+    <param pos="0" name="service.vendor" value="OpenBSD"/>
+    <param pos="0" name="service.family" value="OpenSSH"/>
+    <param pos="0" name="service.product" value="OpenSSH"/>
+    <param pos="0" name="os.vendor" value="HipServ"/>
     <param pos="0" name="os.device" value="Router"/>
     <param pos="0" name="os.family" value="RouterOS"/>
     <param pos="0" name="os.product" value="RouterOS"/>


### PR DESCRIPTION
  <fingerprint pattern="^(?:\d{1,2}\.\d{1,3}\.[a-f\d]{1,3}-)?(\d{1,2}\.\d{1,3}\.[a-f\d]{1,4})-MariaDB-enterprise$" flags="REG_ICASE">
    <description>MariaDB MariaDB Enterprise Edition</description>
    <example service.version="10.1.21">5.5.5-10.1.21-MariaDB-enterprise</example>
    <example service.version="5.5.34">5.5.34-MariaDB-enterprise</example>
    <param pos="1" name="service.version"/>
    <param pos="0" name="service.vendor" value="MariaDB"/>
    <param pos="0" name="service.family" value="MySQL"/>
    <param pos="0" name="service.product" value="MariaDB"/>
    <param pos="0" name="service.edition" value="Enterprise Edition"/>
  </fingerprint>